### PR TITLE
Typo in github url

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A [Substreams _sink_](https://substreams.streamingfast.io/developers-guide/sink-
 Get from the [Releases tab](https://github.com/streamingfast/substreams-sink-kv/releases), or from source:
 
 ```bash
-go install -v github.com/streaminfast/substreams-sink-kv/cmd/substreams-sink-kv
+go install -v github.com/streamingfast/substreams-sink-kv/cmd/substreams-sink-kv@latest
 ```
 
 ## Run


### PR DESCRIPTION
There was a typo in the github url. Also added `@latest` at the end of the url.