### PR TITLE
correct bash code to install go substreaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/insta
 Get from the [Releases tab](https://github.com/streamingfast/substreams-sink-kv/releases), or from source:
 
 ```bash
-go install -v github.com/streaminfast/substreams-sink-kv/cmd/substreams-sink-kv@latest
+go install -v github.com/streamingfast/substreams-sink-kv/cmd/substreams-sink-kv@latest
 ```
 
 ## Running


### PR DESCRIPTION
Corrected the spell in bash code "go install -v github.com/streamingfast/substreams-sink-kv/cmd/substreams-sink-kv@latest"