### PR TITLE
correct bash code to install go substreams-sink-kv

### DIFF
--- a/examples/generic-service/README.md
+++ b/examples/generic-service/README.md
@@ -31,7 +31,7 @@ See https://nodejs.org for installation instructions.
 Get from the [Releases tab](https://github.com/streamingfast/substreams-sink-kv/releases), or from source:
 
 ```bash
-go install -v github.com/streaminfast/substreams-sink-kv/cmd/substreams-sink-kv
+go install -v github.com/streamingfast/substreams-sink-kv/cmd/substreams-sink-kv@latest
 ```
 
 ### Substreams


### PR DESCRIPTION
Corrected the spell in bash code "go install -v github.com/streamingfast/substreams-sink-kv/cmd/substreams-sink-kv@latest"